### PR TITLE
docs: update actions/checkout in documentation to recent version

### DIFF
--- a/test-project/README.md
+++ b/test-project/README.md
@@ -12,7 +12,7 @@ Test Description
 ```yaml
 ...
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: My Test Action
         uses: tj-actions/test-project@v1
 ```

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -12,7 +12,7 @@
 ```yaml
 ...
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: {{ cookiecutter.action_name }}
         uses: {{ cookiecutter.github_username }}/{{ cookiecutter.project_name }}@{{ cookiecutter.version|default("master", true) }}
 ```


### PR DESCRIPTION
Make the version of actions/checkout in READMEs match the version in workflows (and also the version not currently deprecated).